### PR TITLE
Adding CBZ export option with embedded ComicInfo.xml

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -665,6 +665,17 @@ docs = ["docutils", "sphinx (>=5.0)"]
 test = ["pyannotate", "pytest"]
 
 [[package]]
+name = "iso8601"
+version = "2.1.0"
+description = "Simple module to parse ISO 8601 dates"
+optional = false
+python-versions = ">=3.7,<4.0"
+files = [
+    {file = "iso8601-2.1.0-py3-none-any.whl", hash = "sha256:aac4145c4dcb66ad8b648a02830f5e2ff6c24af20f4f482689be402db2429242"},
+    {file = "iso8601-2.1.0.tar.gz", hash = "sha256:6b1d3829ee8921c4301998c909f7829fa9ed3cbdac0d3b16af2d743aed1ba8df"},
+]
+
+[[package]]
 name = "isort"
 version = "5.12.0"
 description = "A Python utility / library to sort Python imports."
@@ -1816,4 +1827,4 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.12,<3.13"
-content-hash = "63b8e80e21fb4c09261573ea0ea72cc5adda25a0e56fbe8d933fcea60578060b"
+content-hash = "077bd581b8559298032bc5b4fc89816b315009acb5cc06a3896e5e31621eae67"

--- a/poetry.lock
+++ b/poetry.lock
@@ -665,17 +665,6 @@ docs = ["docutils", "sphinx (>=5.0)"]
 test = ["pyannotate", "pytest"]
 
 [[package]]
-name = "iso8601"
-version = "2.1.0"
-description = "Simple module to parse ISO 8601 dates"
-optional = false
-python-versions = ">=3.7,<4.0"
-files = [
-    {file = "iso8601-2.1.0-py3-none-any.whl", hash = "sha256:aac4145c4dcb66ad8b648a02830f5e2ff6c24af20f4f482689be402db2429242"},
-    {file = "iso8601-2.1.0.tar.gz", hash = "sha256:6b1d3829ee8921c4301998c909f7829fa9ed3cbdac0d3b16af2d743aed1ba8df"},
-]
-
-[[package]]
 name = "isort"
 version = "5.12.0"
 description = "A Python utility / library to sort Python imports."
@@ -1827,4 +1816,4 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.12,<3.13"
-content-hash = "077bd581b8559298032bc5b4fc89816b315009acb5cc06a3896e5e31621eae67"
+content-hash = "63b8e80e21fb4c09261573ea0ea72cc5adda25a0e56fbe8d933fcea60578060b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ pypinyin = "^0.49.0"
 qt-material = "^2.14"
 beautifulsoup4 = "^4.12.2"
 qrcode = "^7.4.2"
+iso8601 = "^2.1.0"
 
 [[tool.poetry.source]]
 name = "mirrors"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,6 @@ pypinyin = "^0.49.0"
 qt-material = "^2.14"
 beautifulsoup4 = "^4.12.2"
 qrcode = "^7.4.2"
-iso8601 = "^2.1.0"
 
 [[tool.poetry.source]]
 name = "mirrors"

--- a/src/ComicInfoXML.py
+++ b/src/ComicInfoXML.py
@@ -1,15 +1,14 @@
+"""
+该模块包含了单章节漫画的元数据, 用于创造ComicInfo.xml
+https://anansi-project.github.io/docs/comicinfo/documentation
+"""
+
 import os
 from xml.sax.saxutils import escape
-from iso8601 import parse_date
-
-
-def xml_write_simple_tag(f, name, val, indent=1):
-    if val != "":
-        f.write(f'{" " * indent}<{name}>{escape(str(val))}</{name}>\n')
-
+from datetime import datetime
 
 class ComicInfoXML:
-    # https://anansi-project.github.io/docs/comicinfo/documentation
+    """漫画章节元数据，用于创造ComicInfo.xml"""
     def __init__(
             self,
             series_info=None,
@@ -23,6 +22,11 @@ class ComicInfoXML:
             self.add_episode_info(episode_info)
 
     def add_series_info(self, series_info: dict) -> None:
+        """导入单本漫画元数据
+
+        Args:
+            series_info (dict): 单本漫画元数据
+        """
         self.metadata["Series"] = series_info.get("title", "")
         self.metadata["Publisher"] = "bilibili漫画"
         self.metadata["Writer"] = series_info.get("author_name", "")
@@ -31,38 +35,64 @@ class ComicInfoXML:
         self.metadata["Count"] = series_info.get("last_ord", "")
 
     def add_episode_info(self, episode_info: dict) -> None:
+        """导入漫画章节元数据
+
+        Args:
+            episode_info (dict): 漫画章节元数据
+        """
         self.metadata["Title"] = episode_info.get("title", "")
         self.metadata["Number"] = episode_info.get("ord", "")
         self.metadata["PageCount"] = episode_info.get("image_count", "")
 
         if "pub_time" in episode_info:
-            datetime = parse_date(episode_info["pub_time"])
-            self.metadata["Year"] = datetime.year
-            self.metadata["Month"] = datetime.month
-            self.metadata["Day"] = datetime.day
+            try:
+                dt = datetime.strptime(episode_info["pub_time"], "%Y-%m-%d %H:%M:%S")
+                self.metadata["Year"] = dt.year
+                self.metadata["Month"] = dt.month
+                self.metadata["Day"] = dt.day
+            except ValueError:
+                self.metadata["Year"] = ""
+                self.metadata["Month"] = ""
+                self.metadata["Day"] = ""
 
     def serialize(self, output_path: str) -> None:
+        """创造ComicInfo.xml
+
+        Args:
+            output_path (str): ComicInfo.xml写出路径
+        """
         with open(os.path.join(output_path, 'ComicInfo.xml'), 'w', encoding="utf-8") as f:
             f.write('<?xml version="1.0" encoding="utf-8"?>\n')
             f.write('<ComicInfo xmlns:xsd="http://www.w3.org/2001/XMLSchema" '
                     'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">\n')
 
-            xml_write_simple_tag(f, "Manga", 'Yes')
+            self.xml_write_simple_tag(f, "Manga", 'Yes')
 
-            xml_write_simple_tag(f, "Series", self.metadata["Series"])
-            xml_write_simple_tag(f, "Publisher", self.metadata["Publisher"])
-            xml_write_simple_tag(f, "Writer", self.metadata["Writer"])
-            xml_write_simple_tag(f, "Genre", self.metadata["Genre"])
-            xml_write_simple_tag(f, "Summary", self.metadata["Summary"])
-            xml_write_simple_tag(f, "Count", self.metadata["Count"])
+            self.xml_write_simple_tag(f, "Series", self.metadata["Series"])
+            self.xml_write_simple_tag(f, "Publisher", self.metadata["Publisher"])
+            self.xml_write_simple_tag(f, "Writer", self.metadata["Writer"])
+            self.xml_write_simple_tag(f, "Genre", self.metadata["Genre"])
+            self.xml_write_simple_tag(f, "Summary", self.metadata["Summary"])
+            self.xml_write_simple_tag(f, "Count", self.metadata["Count"])
 
-            xml_write_simple_tag(f, "Title", self.metadata["Title"])
-            xml_write_simple_tag(f, "Number", self.metadata["Number"])
-            xml_write_simple_tag(f, "PageCount", self.metadata["PageCount"])
+            self.xml_write_simple_tag(f, "Title", self.metadata["Title"])
+            self.xml_write_simple_tag(f, "Number", self.metadata["Number"])
+            self.xml_write_simple_tag(f, "PageCount", self.metadata["PageCount"])
 
-            xml_write_simple_tag(f, "Year", self.metadata["Year"])
-            xml_write_simple_tag(f, "Month", self.metadata["Month"])
-            xml_write_simple_tag(f, "Day", self.metadata["Day"])
+            self.xml_write_simple_tag(f, "Year", self.metadata["Year"])
+            self.xml_write_simple_tag(f, "Month", self.metadata["Month"])
+            self.xml_write_simple_tag(f, "Day", self.metadata["Day"])
 
             f.write('</ComicInfo>')
 
+    def xml_write_simple_tag(self, f, name: str, val: str, indent=1) -> None:
+        """xml帮手函数
+
+        Args:
+            f (file descriptor)
+            name (str): XML tag
+            val (str): XML value
+            output_path (str): ComicInfo.xml写出路径
+        """
+        if val != "":
+            f.write(f'{" " * indent}<{name}>{escape(str(val))}</{name}>\n')

--- a/src/ComicInfoXML.py
+++ b/src/ComicInfoXML.py
@@ -1,0 +1,68 @@
+import os
+from xml.sax.saxutils import escape
+from iso8601 import parse_date
+
+
+def xml_write_simple_tag(f, name, val, indent=1):
+    if val != "":
+        f.write(f'{" " * indent}<{name}>{escape(str(val))}</{name}>\n')
+
+
+class ComicInfoXML:
+    # https://anansi-project.github.io/docs/comicinfo/documentation
+    def __init__(
+            self,
+            series_info=None,
+            episode_info=None,
+    ) -> None:
+        self.metadata = {}
+
+        if series_info:
+            self.add_series_info(series_info)
+        if episode_info:
+            self.add_episode_info(episode_info)
+
+    def add_series_info(self, series_info: dict) -> None:
+        self.metadata["Series"] = series_info.get("title", "")
+        self.metadata["Publisher"] = "bilibili漫画"
+        self.metadata["Writer"] = series_info.get("author_name", "")
+        self.metadata["Genre"] = series_info.get("styles", "")
+        self.metadata["Summary"] = series_info.get("evaluate", "")
+        self.metadata["Count"] = series_info.get("last_ord", "")
+
+    def add_episode_info(self, episode_info: dict) -> None:
+        self.metadata["Title"] = episode_info.get("title", "")
+        self.metadata["Number"] = episode_info.get("ord", "")
+        self.metadata["PageCount"] = episode_info.get("image_count", "")
+
+        if "pub_time" in episode_info:
+            datetime = parse_date(episode_info["pub_time"])
+            self.metadata["Year"] = datetime.year
+            self.metadata["Month"] = datetime.month
+            self.metadata["Day"] = datetime.day
+
+    def serialize(self, output_path: str) -> None:
+        with open(os.path.join(output_path, 'ComicInfo.xml'), 'w', encoding="utf-8") as f:
+            f.write('<?xml version="1.0" encoding="utf-8"?>\n')
+            f.write('<ComicInfo xmlns:xsd="http://www.w3.org/2001/XMLSchema" '
+                    'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">\n')
+
+            xml_write_simple_tag(f, "Manga", 'Yes')
+
+            xml_write_simple_tag(f, "Series", self.metadata["Series"])
+            xml_write_simple_tag(f, "Publisher", self.metadata["Publisher"])
+            xml_write_simple_tag(f, "Writer", self.metadata["Writer"])
+            xml_write_simple_tag(f, "Genre", self.metadata["Genre"])
+            xml_write_simple_tag(f, "Summary", self.metadata["Summary"])
+            xml_write_simple_tag(f, "Count", self.metadata["Count"])
+
+            xml_write_simple_tag(f, "Title", self.metadata["Title"])
+            xml_write_simple_tag(f, "Number", self.metadata["Number"])
+            xml_write_simple_tag(f, "PageCount", self.metadata["PageCount"])
+
+            xml_write_simple_tag(f, "Year", self.metadata["Year"])
+            xml_write_simple_tag(f, "Month", self.metadata["Month"])
+            xml_write_simple_tag(f, "Day", self.metadata["Day"])
+
+            f.write('</ComicInfo>')
+

--- a/src/Episode.py
+++ b/src/Episode.py
@@ -18,6 +18,7 @@ from py7zr import SevenZipFile
 from PyPDF2 import PdfReader, PdfWriter
 from retrying import retry
 
+from src.ComicInfoXML import ComicInfoXML
 from src.Utils import (
     MAX_RETRY_LARGE,
     MAX_RETRY_SMALL,
@@ -54,6 +55,9 @@ class Episode:
         self.size = episode["size"]
         self.imgs_token = None
         self.author = comic_info["author_name"]
+
+        if mainGUI.getConfig("save_method") == "Cbz压缩包":
+            self.comicinfoxml = ComicInfoXML(comic_info, episode)
 
         # ?###########################################################
         # ? 修复标题中的特殊字符
@@ -237,6 +241,9 @@ class Episode:
         elif save_method == "Zip压缩包":
             self.saveToZip(imgs_path)
             save_path = f"{self.epi_path}.zip"
+        elif save_method == "Cbz压缩包":
+            self.saveToCbz(imgs_path)
+            save_path = f"{self.epi_path}.cbz"
         return save_path
 
     ############################################################
@@ -435,6 +442,45 @@ class Episode:
             logger.exception(e)
             self.mainGUI.signal_message_box.emit(
                 f"《{self.comic_name}》章节：{self.title} 保存图片到Zip多次后失败!\n已暂时跳过此章节!\n请重新尝试或者重启软件!\n\n更多详细信息请查看日志文件, 或联系开发者！"
+            )
+
+    ############################################################
+
+    def saveToCbz(self, imgs_path: list[str]) -> None:
+        """将图片保存到Cbz压缩文件
+
+        Args:
+            imgs_path (list): 临时图片路径列表
+        """
+
+        self.saveToFolder(imgs_path)
+        self.comicinfoxml.serialize(self.epi_path)
+
+        @retry(stop_max_attempt_number=5)
+        def _() -> None:
+            try:
+                with ZipFile(f"{self.epi_path}.cbz", "w") as z:
+                    # 压缩文件里不要子目录，全部存在根目录
+                    for root, _dirs, files in os.walk(self.epi_path):
+                        for file in files:
+                            z.write(
+                                os.path.join(root, file),
+                                os.path.basename(os.path.join(root, file)),
+                            )
+                    shutil.rmtree(self.epi_path)
+            except OSError as e:
+                logger.error(
+                    f"《{self.comic_name}》章节：{self.title} 保存图片到Cbz失败! 重试中...\n{e}"
+                )
+                raise e
+
+        try:
+            _()
+        except OSError as e:
+            logger.error(f"《{self.comic_name}》章节：{self.title} 保存图片到Cbz多次后失败!\n{e}")
+            logger.exception(e)
+            self.mainGUI.signal_message_box.emit(
+                f"《{self.comic_name}》章节：{self.title} 保存图片到Cbz多次后失败!\n已暂时跳过此章节!\n请重新尝试或者重启软件!\n\n更多详细信息请查看日志文件, 或联系开发者！"
             )
 
     ############################################################

--- a/src/Episode.py
+++ b/src/Episode.py
@@ -242,7 +242,7 @@ class Episode:
         elif self.save_method == "Zip压缩包":
             self.saveToZip(imgs_path)
             save_path = f"{self.epi_path}.zip"
-        elif save_method == "Cbz压缩包":
+        elif self.save_method == "Cbz压缩包":
             self.saveToCbz(imgs_path)
             save_path = f"{self.epi_path}.cbz"
         return save_path

--- a/src/ui/PySide_src/mainWindow.ui
+++ b/src/ui/PySide_src/mainWindow.ui
@@ -1006,6 +1006,25 @@ li.checked::marker { content: &quot;\2612&quot;; }
                </property>
               </widget>
              </item>
+             <item>
+              <widget class="QRadioButton" name="radioButton_save_method_Cbz">
+               <property name="minimumSize">
+                <size>
+                 <width>60</width>
+                 <height>0</height>
+                </size>
+               </property>
+               <property name="text">
+                <string>Cbz压缩包</string>
+               </property>
+               <property name="checked">
+                <bool>false</bool>
+               </property>
+               <property name="autoRepeat">
+                <bool>false</bool>
+               </property>
+              </widget>
+             </item>
             </layout>
            </widget>
           </item>


### PR DESCRIPTION
### Background
- `ComicInfo.xml` is a metadata evaluation file used by various comics media server like komga and kavita. 
  - https://github.com/anansi-project/comicinfo
- `cbz` is effectively `zip` but far more recognizable by media servers along with the ability to embed metadata like the `ComicInfo.xml` mentioned above
  - Some media server may not recognize the metadata if the format is not in `cbz`

### Changes
Created `ComicInfoXML` class as metadata container and serializer
Added option to export comics as CBZ in UI and backend

### Preview
![2023-11-26_19-30](https://github.com/Zeal-L/BiliBili-Manga-Downloader/assets/70647872/aa597d37-d30f-47fa-be86-bf1468c04129)
![2023-11-26_19-33](https://github.com/Zeal-L/BiliBili-Manga-Downloader/assets/70647872/548c4042-82c2-41a1-960b-7fb6733b5472)

