### PR TITLE
🐛修复一个运行时错误

### DIFF
--- a/src/ComicInfoXML.py
+++ b/src/ComicInfoXML.py
@@ -89,14 +89,16 @@ class ComicInfoXML:
 
             f.write("</ComicInfo>")
 
-    def xml_write_simple_tag(self, f, name: str, val: str, indent=1) -> None:
+    def xml_write_simple_tag(self, f, name: str, val, indent=1) -> None:
         """xml帮手函数
 
         Args:
             f (file descriptor)
             name (str): XML tag
-            val (str): XML value
+            val : XML value
             output_path (str): ComicInfo.xml写出路径
         """
+        if val.__class__ != "str":
+            val = str(val)
         if val != "":
             f.write(f'{" " * indent}<{name}>{escape(val)}</{name}>\n')

--- a/src/ComicInfoXML.py
+++ b/src/ComicInfoXML.py
@@ -98,7 +98,7 @@ class ComicInfoXML:
             val : XML value
             output_path (str): ComicInfo.xml写出路径
         """
-        if val.__class__ != "str":
+        if not isinstance(val, str):
             val = str(val)
         if val != "":
             f.write(f'{" " * indent}<{name}>{escape(val)}</{name}>\n')


### PR DESCRIPTION
```python
self.xml_write_simple_tag(f, "Count", self.metadata["Count"])
```
此操作为 ```xml_write_simple_tag``` 传入了 ```int```。而函数中的 ```str()``` 转换被 pylint 自动优化掉了。运行时会卡死，可以改源码捕获到错误。
```
'int' object has no attribute 'replace'
'int' object has no attribute 'replace'
'int' object has no attribute 'replace'
'int' object has no attribute 'replace'
'int' object has no attribute 'replace'
'int' object has no attribute 'replace'
```