### PR TITLE
:bug: 修复ComicInfo.xml里count标签错误

### DIFF
--- a/src/BiliPlus.py
+++ b/src/BiliPlus.py
@@ -144,7 +144,7 @@ class BiliPlusComic(Comic):
         self.data["hall_icon_text"] = ""
         self.data["tags"] = []
         self.data["is_finish"] = True if renewal_time == "已完结" else False
-        self.data["last_ord"] = len(ep_list)
+        self.data["total"] = len(ep_list)
         self.data["ep_list"] = ep_list[::-1]
         if self.comic_id in self.mainGUI.my_library:
             self.data["save_path"] = self.mainGUI.my_library[self.comic_id].get("comic_path")

--- a/src/ComicInfoXML.py
+++ b/src/ComicInfoXML.py
@@ -34,7 +34,7 @@ class ComicInfoXML:
         self.metadata["Writer"] = series_info.get("author_name", "")
         self.metadata["Genre"] = series_info.get("styles", "")
         self.metadata["Summary"] = series_info.get("evaluate", "")
-        self.metadata["Count"] = series_info.get("last_ord", "")
+        self.metadata["Count"] = series_info.get("total", "")
 
     def add_episode_info(self, episode_info: dict) -> None:
         """导入漫画章节元数据


### PR DESCRIPTION
按照CBZ格式规范，Count标签应为总章节数，而不是(last_ord)最后章节名称，故改为获取(total)总章节数