### PR TITLE
🐛修复BiliPlus解析失败问题(不使用重定向)

### DIFF
--- a/src/BiliPlus.py
+++ b/src/BiliPlus.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING
 
 import time
 import requests
-from bs4 import BeautifulSoup
+from bs4 import BeautifulSoup, Tag
 from retrying import retry
 
 from src.Comic import Comic
@@ -362,7 +362,7 @@ class BiliPlusEpisode(Episode):
             images = soup.find_all("img", {"class": "comic-single"})
 
             @retry(stop_max_delay=MAX_RETRY_SMALL, wait_exponential_multiplier=RETRY_WAIT_EX)
-            def _(index, img_element) -> bool:
+            def _(index: int, img_element: Tag) -> bool:
                 img_url = f'https://www.biliplus.com/manga/{img_element["_src"]}'
                 res = requests.get(img_url, headers=self.headers, allow_redirects=False)
                 if res.status_code != 301:


### PR DESCRIPTION
# 功能描述

目前BiliPlus漫画页面的html里不再直接包含图片地址，取而代之的是一些query参数，通过这些参数发起的请求会被重定向到真正的图片地址

例如：
某图片的query参数为:
 `?act=get_image_url&epid=595701&request_time=1721133361&file=bb35c716a7781be297f57f1e39b21dfc0375e773.jpg&append=`
禁用`requests`的重定向，然后带cookie发送以下请求
`https://www.biliplus.com/manga/?act=get_image_url&epid=595701&request_time=1721133361&file=bb35c716a7781be297f57f1e39b21dfc0375e773.jpg&append=`
从响应头中就能得到真正的图片地址

这个PR对图片地址的解析就是基于上面的例子
# 为什么不用多线程

经过我的测试，用多线程进行`发请求拿图片地址`操作，极易触发BiliPlus的503错误
即使把`executor`大小设置为4，503错误依然会频繁出现
大概是因为在外面有16个并发(16个进度条在工作)，即使每个进度条只并发4个，总数也有64

# 优劣

**优:** 只修改一个文件，不破坏`DownloadManager.py`和`Episode.py`的抽象
**劣:** 每个进度条进行`解析章节图片地址`的耗时变得很长，且在用户界面上完全没有提示

在我的网络环境中，无论是否使用重定向，下载的总耗时都差不多
解决这个issue #154 