### PR TITLE
🐛修复BiliPlus解析失败问题(使用重定向)

### DIFF
--- a/src/BiliPlus.py
+++ b/src/BiliPlus.py
@@ -230,7 +230,7 @@ class BiliPlusComic(Comic):
             ep_items = soup.find_all("div", {"class": "episode-item"})
             ep_available = []
             for ep in ep_items:
-                if "https://" in ep.img["src"]:
+                if ep.img.get("_src") is not None:
                     ep_available.append(ep.a["href"].split("epid=")[1])
             total_ep_element = soup.select_one("center p")
             if total_ep_element:
@@ -244,7 +244,7 @@ class BiliPlusComic(Comic):
                     soup = BeautifulSoup(page_html, "html.parser")
                     ep_items = soup.find_all("div", {"class": "episode-item"})
                     for ep in ep_items:
-                        if "https://" in ep.img["src"]:
+                        if ep.img.get("_src") is not None:
                             ep_available.append(ep.a["href"].split("epid=")[1])
 
             unlock_times = 0
@@ -361,9 +361,8 @@ class BiliPlusEpisode(Episode):
             soup = BeautifulSoup(biliplus_html, "html.parser")
             images = soup.find_all("img", {"class": "comic-single"})
             for img in images:
-                img_url = img["_src"]
-                url, token = img_url.split("?token=")
-                biliplus_imgs_token.append({"url": url, "token": token})
+                img_url = f'https://www.biliplus.com/manga/{img["_src"]}'
+                biliplus_imgs_token.append({"url": img_url})
             self.imgs_token = biliplus_imgs_token
             if not biliplus_imgs_token:
                 msg = f"《{self.comic_name}》章节：{self.title} " \

--- a/src/DownloadManager.py
+++ b/src/DownloadManager.py
@@ -151,7 +151,10 @@ class DownloadManager:
             if self.terminated:
                 epi.clear(imgs_path)
                 return
-            img_url = f"{img['url']}?token={img['token']}"
+            if img.get("token") is not None:
+                img_url = f"{img['url']}?token={img['token']}"
+            else:
+                img_url = img["url"]
             img_path = epi.downloadImg(index, img_url)
             if img_path is None:
                 self.reportError(curr_id)

--- a/src/Episode.py
+++ b/src/Episode.py
@@ -527,7 +527,11 @@ class Episode:
         @retry(stop_max_delay=MAX_RETRY_LARGE, wait_exponential_multiplier=RETRY_WAIT_EX)
         def _() -> bytes:
             try:
-                res = requests.get(img_url, timeout=TIMEOUT_LARGE)
+                if img_url.find("token") != -1:
+                    res = requests.get(img_url, timeout=TIMEOUT_LARGE)
+                else:
+                    res = requests.get(img_url, headers=self.headers, timeout=TIMEOUT_LARGE)
+
             except requests.RequestException as e:
                 logger.warning(
                     f"《{self.comic_name}》章节：{self.title} - {index} - {img_url} 下载图片失败! 重试中...\n{e}"
@@ -562,7 +566,7 @@ class Episode:
 
         # ?###########################################################
         # ? 保存图片
-        img_format = img_url.split(".")[-1].split("?")[0].lower()
+        img_format = img_url.split(".")[-1].split("?")[0].lower().replace("&append=", "")
         path_to_save = os.path.join(self.save_path, f"{self.real_ord}_{index}.{img_format}")
 
         @retry(stop_max_attempt_number=5)


### PR DESCRIPTION
# 功能描述

目前BiliPlus漫画页面的html里不再直接包含图片地址，取而代之的是一些query参数，通过这些参数发起的请求会被重定向到真正的图片地址

例如：
某图片的query参数为:
 `?act=get_image_url&epid=595701&request_time=1721133361&file=bb35c716a7781be297f57f1e39b21dfc0375e773.jpg&append=`
因为`requests`自带重定向功能，带cookie向以下url发送请求
`https://www.biliplus.com/manga/?act=get_image_url&epid=595701&request_time=1721133361&file=bb35c716a7781be297f57f1e39b21dfc0375e773.jpg&append=`
即可得到图片

这个PR将上述的url直接给到`DownloadManager`，不带token
`DownloadManager`通过是否有token判断url是否来自BiliPlus
从而分别处理两种下载方式

# 优劣
**优:** 使用重定向相当于图片地址解析与下载同时进行，能将下载进度迅速反映在用户界面上
**劣:** 改动的文件较多，且破坏了`DownloadManager.py`和`Episode.py`的抽象

在我的网络环境中，无论是否使用重定向，下载的总耗时都差不多
解决这个issue #154 