### PR TITLE
🐛修复下载功能失效问题

### DIFF
--- a/src/Episode.py
+++ b/src/Episode.py
@@ -97,7 +97,7 @@ class Episode:
             "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36",
             "origin": "https://manga.bilibili.com",
             "referer": f"https://manga.bilibili.com/detail/mc{comic_id}/{self.id}?from=manga_homepage",
-            "cookie": f"SESSDATA={mainGUI.getConfig('cookie')}",
+            "cookie": f"SESSDATA={mainGUI.getConfig('cookie')};buvid3={mainGUI.getConfig('buvid3')};",
         }
         self.save_path = comic_info["save_path"]
         self.epi_path = os.path.join(self.save_path, f"{self.title}")


### PR DESCRIPTION
目前B漫的
https://manga.bilibili.com/twirp/comic.v1.Comic/ImageToken
接口需要额外在cookie里带`buvid3`才能通过验证，而之前只需要`SESSDATA`

这个PR使软件启动时检查配置文件里是否有`buvid3`，如果没有则尝试获取一个。
并向`Episode.py`中默认headers的cookie添加`buvid3`(从配置文件中获取)，以便通过上述接口验证

解决这些issue #170 #171 #172